### PR TITLE
fix: make deploy a slice, use it to config multiple environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ file present. See [Examples](#examples) for help with this.
 $ build-configs generate
 ```
 
+It is also possible to configure build-configs to leave otherwise templated be,
+similarly to the `.gitignore` file in a Git repository. The file used is called
+`.bcignore`, and takes a direct list of paths (globs are currently unsupported)
+to skip templating:
+
+```gitignore
+# ignore the flake, we customize it further.
+flake.nix
+```
+
 ## Examples
 
 Some example configurations for our template types exist in the

--- a/examples/go-lambda/.gitignore
+++ b/examples/go-lambda/.gitignore
@@ -1,0 +1,3 @@
+**/*
+!.gitignore
+!build-configs.yaml

--- a/examples/go-lambda/build-configs.yaml
+++ b/examples/go-lambda/build-configs.yaml
@@ -9,7 +9,8 @@ parameters:
   quirk:
     service: lambdatest
   deploy:
-    roleArn: 'arn:aws:iam::1234567890:role/gha-lambda-test-deploy-dev-role'
+    - environment: dev
+      if: github.ref == 'refs/heads/main'
   nix:
     vendorHash: ''
     goPackage: go_1_22

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -26,10 +26,6 @@ var generateCmd = &cobra.Command{
 			return fmt.Errorf("could not create templater: %v", err)
 		}
 
-		if debug {
-			fmt.Printf("%+v\n", t)
-		}
-
 		return t.Render()
 	},
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,9 +1,11 @@
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/ALT-F4-LLC/build-configs/internal/config"
+	"github.com/spf13/cobra"
+)
 
 var (
-	debug      bool
 	configFile string
 )
 
@@ -20,6 +22,6 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "debug mode")
+	rootCmd.PersistentFlags().BoolVarP(&config.Debug, "debug", "D", false, "debug mode")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config-file", "c", "", "path to the config file")
 }

--- a/internal/config/deploy.go
+++ b/internal/config/deploy.go
@@ -33,7 +33,7 @@ type DeployConfig struct {
 // contextually
 func (c *DeployConfig) UnmarshalJSON(data []byte) error {
 	defaultRole := fmt.Sprintf(
-		"arn:aws:iam::%s:role/gha-%s-deploy-%s",
+		"arn:aws:iam::%s:role/altf4llc-gha-%s-deploy-%s",
 		DefaultAccount,
 		Cfg.Name,
 		DefaultEnvironment,

--- a/internal/config/deploy.go
+++ b/internal/config/deploy.go
@@ -1,12 +1,56 @@
 package config
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	DefaultEnvironment = "unspecified"
+	DefaultAccount     = "677459762413"
+	DefaultRegion      = "us-west-2"
+)
+
 type DeployConfig struct {
+	// Environment is the name of the environment to deploy to.
+	Environment string `json:"environment" yaml:"environment"`
+
+	// Account is the AWS account ID used to deploy to this environment.
+	Account string `json:"account,omitempty" yaml:"account,omitempty"`
+
+	// RoleARN is the ARN of the role used to deploy to this environment.
 	RoleARN string `json:"roleArn,omitempty" yaml:"roleArn,omitempty"`
-	Region  string `json:"region,omitempty" yaml:"region,omitempty"`
+
+	// Region is the AWS region this environment will be deployed into.
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+
+	// If is the value of the `if` field for the GitHub Actions job that will
+	// deploy this application.
+	If string `json:"if,omitempty" yaml:"if,omitempty"`
 }
 
-func NewDeployConfig() DeployConfig {
-	return DeployConfig{
-		Region: "us-west-2",
+// UnmarshalJSON unmarshals the JSON blob while adding default values
+// contextually
+func (c *DeployConfig) UnmarshalJSON(data []byte) error {
+	defaultRole := fmt.Sprintf(
+		"arn:aws:iam::%s:role/gha-%s-deploy-%s",
+		DefaultAccount,
+		Cfg.Name,
+		DefaultEnvironment,
+	)
+
+	type Alias DeployConfig
+	deploy := Alias{
+		Environment: DefaultEnvironment,
+		Account:     DefaultAccount,
+		RoleARN:     defaultRole,
+		Region:      DefaultRegion,
 	}
+
+	if err := json.Unmarshal(data, &deploy); err != nil {
+		return err
+	}
+	*c = DeployConfig(deploy)
+
+	return nil
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,0 +1,4 @@
+package config
+
+var Cfg Config
+var Debug bool = false

--- a/internal/config/go_cobra_cli.go
+++ b/internal/config/go_cobra_cli.go
@@ -4,6 +4,8 @@ import (
 	"github.com/ALT-F4-LLC/build-configs/internal/templates"
 )
 
+const GoCobraCliName = "go-cobra-cli"
+
 type GoCobraCliConfig struct {
 	Config
 	GoVersion      string             `json:"goVersion,omitempty" yaml:"goVersion,omitempty"`

--- a/internal/config/go_lambda.go
+++ b/internal/config/go_lambda.go
@@ -4,13 +4,15 @@ import (
 	"github.com/ALT-F4-LLC/build-configs/internal/templates"
 )
 
+const GoLambdaName = "go-lambda"
+
 type GoLambdaConfig struct {
 	Config
 	GoVersion      string             `json:"goVersion,omitempty" yaml:"goVersion,omitempty"`
 	Lint           GolangCILintConfig `json:"lint,omitempty" yaml:"lint,omitempty"`
 	Nix            NixGoConfig        `json:"nix,omitempty" yaml:"nix,omitempty"`
 	Quirk          QuirkConfig        `json:"quirk,omitempty" yaml:"quirk,omitempty"`
-	Deploy         DeployConfig       `json:"deploy,omitempty" yaml:"deploy,omitempty"`
+	Deploy         []DeployConfig     `json:"deploy,omitempty" yaml:"deploy,omitempty"`
 	PrivateModules string             `json:"privateModules,omitempty" yaml:"privateModules,omitempty"`
 	Lambdas        []string           `json:"lambdas,omitempty" yaml:"lambdas,omitempty"`
 	OpenAPI        OpenAPIConfig      `json:"openapi,omitempty" yaml:"openapi,omitempty"`
@@ -22,7 +24,7 @@ func NewGoLambdaConfig(c Config) GoLambdaConfig {
 		GoVersion: "1.22",
 		Lint:      NewGolangCiLintConfig(),
 		Quirk:     NewQuirkConfig(c),
-		Deploy:    NewDeployConfig(),
+		Deploy:    []DeployConfig{},
 		Lambdas:   []string{c.Name},
 		OpenAPI:   NewOpenAPIConfig(),
 

--- a/internal/templates/templates/go-lambda/.github__workflows__flake.yaml
+++ b/internal/templates/templates/go-lambda/.github__workflows__flake.yaml
@@ -71,9 +71,12 @@ jobs:
         if: success() || failure()
       {{- end }}
 
-  deploy-dev:
+  {{ range .Deploy }}
+  deploy-{{ .Environment }}:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    {{- if .If }}
+    if: {{ .If }}
+    {{- end }}
     permissions:
       id-token: write
       contents: read
@@ -81,14 +84,14 @@ jobs:
     strategy:
       matrix:
         profile:
-          {{- range .Lambdas }}
+          {{- range $.Lambdas }}
           - {{ . }}
           {{- end }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: {{ .Deploy.Region }}
-          role-to-assume: {{ .Deploy.RoleARN }}
+          aws-region: {{ .Region }}
+          role-to-assume: {{ .RoleARN }}
       - uses: actions/download-artifact@v4
         with:
           name: "zip-${{"{{"}} matrix.profile {{"}}"}}"
@@ -100,4 +103,5 @@ jobs:
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}
           name: ${{"{{"}} env.CACHIX_BINARY_CACHE {{"}}"}}
-      - run: nix develop -c just deploy dev "${{"{{"}} matrix.profile {{"}}"}}"
+      - run: nix develop -c just deploy {{ .Environment }} "${{"{{"}} matrix.profile {{"}}"}}"
+  {{- end }}


### PR DESCRIPTION
## Changes

- Adds the ability to configure multiple environments to deploy to with the `parameters.deploy` configuration.

## Example Config

```yaml
---
projectName: hello
template: go-lambda
parameters:
  deploy:
    - environment: dev
    - environment: prod
```

Generates as:

```yaml
deploy:
  - environment: dev
    account: '677459762413'
    region: 'us-west-2'
    roleArn: 'arn:aws:iam::677459762413:role/altf4llc-gha-hello-deploy-dev'
  - environment: prod
    account: '677459762413'
    region: 'us-west-2'
    roleArn: 'arn:aws:iam::677459762413:role/altf4llc-gha-hello-deploy-prod'
```

Note that `account`, `region` and `roleArn` are defaulted and/or customized by other config parameters like `projectName`.