### PR TITLE
fix: remove DetSys nix installer from templates

### DIFF
--- a/internal/templates/templates/go-cobra-cli/.github__workflows__flake.yaml
+++ b/internal/templates/templates/go-cobra-cli/.github__workflows__flake.yaml
@@ -13,7 +13,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
+        with:
+          enable_kvm: true
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}
@@ -26,7 +28,9 @@ jobs:
       - check
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
+        with:
+          enable_kvm: true
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}

--- a/internal/templates/templates/go-lambda/.github__workflows__flake.yaml
+++ b/internal/templates/templates/go-lambda/.github__workflows__flake.yaml
@@ -13,7 +13,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
+        with:
+          enable_kvm: true
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}
@@ -32,7 +34,9 @@ jobs:
           - {{ . }}
           {{- end }}
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
+        with:
+          enable_kvm: true
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}
@@ -89,7 +93,9 @@ jobs:
         with:
           name: "zip-${{"{{"}} matrix.profile {{"}}"}}"
           path: "dist/${{"{{"}} matrix.profile {{"}}"}}/lambda.zip"
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
+        with:
+          enable_kvm: true
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{"{{"}} secrets.ALTF4LLC_CACHIX_AUTH_TOKEN {{"}}"}}


### PR DESCRIPTION
## Changes

- Replaces the Determinate Systems Nix installer action in GitHub Actions with `cachix/install-nix-action@v25`.