### PR TITLE
go-lambda template updates

### DIFF
--- a/examples/go-lambda/build-configs.yaml
+++ b/examples/go-lambda/build-configs.yaml
@@ -14,3 +14,5 @@ parameters:
     vendorHash: ''
     goPackage: go_1_22
     buildGoModule: buildGo122Module
+  openapi:
+    enable: true

--- a/internal/config/openapi.go
+++ b/internal/config/openapi.go
@@ -1,0 +1,11 @@
+package config
+
+type OpenAPIConfig struct {
+	Enable bool `json:"enable" yaml:"enable"`
+}
+
+func NewOpenAPIConfig() OpenAPIConfig {
+	return OpenAPIConfig{
+		Enable: false,
+	}
+}

--- a/internal/templates/templates/go-lambda/justfile
+++ b/internal/templates/templates/go-lambda/justfile
@@ -15,11 +15,10 @@ check:
 package profile{{ if .PrivateModules }} netrc="/tmp/.netrc=/tmp/.netrc"{{ end }}:
     #!/usr/bin/env bash
     set -euxo pipefail
-    DERIVATION=$(just build "{{"{{"}} profile {{"}}"}}" "{{"{{"}} netrc {{"}}"}}")
+    DERIVATION=$(just build "{{"{{"}} profile {{"}}"}}.bootstrap" "{{"{{"}} netrc {{"}}"}}")
     OUTPUT=$(echo $DERIVATION | jq -r ".[0].outputs.out")
     mkdir -p dist/{{"{{"}} profile {{"}}"}}
-    install -m 755 $OUTPUT/bin/{{"{{"}} profile {{"}}"}} dist/{{"{{"}} profile {{"}}"}}/bootstrap
-    (cd dist/{{"{{"}} profile {{"}}"}} && zip lambda.zip bootstrap)
+    cp --no-preserve=mode $OUTPUT dist/{{"{{"}} profile {{"}}"}}/lambda.zip
 
 package-all{{ if .PrivateModules }} netrc="/tmp/.netrc=/tmp/.netrc"{{ end }}:
     {{- range .Lambdas }}

--- a/internal/templates/templates/go-lambda/justfile
+++ b/internal/templates/templates/go-lambda/justfile
@@ -54,3 +54,13 @@ deploy-all environment:
     {{- range .Lambdas }}
     just deploy "{{"{{"}} environment {{"}}"}}" "{{.}}"
     {{- end }}
+
+{{ if .OpenAPI.Enable -}}
+build-client:
+    #!/usr/bin/env bash
+    DERIVATION=$(just build client "{{"{{"}} netrc {{"}}"}}")
+    OUTPUT=$(echo $DERIVATION | jq -r ".[0].outputs.out")
+    rm -rf pkg/client
+    cp -r --no-preserve=mode $OUTPUT pkg/client
+    git add pkg/client
+{{- end }}

--- a/internal/templates/templates/go-lambda/nix__client.nix
+++ b/internal/templates/templates/go-lambda/nix__client.nix
@@ -1,0 +1,26 @@
+{ runCommand, openapi-generator-cli }:
+runCommand "client"
+{
+  src = ../api;
+  buildInputs = [ openapi-generator-cli ];
+} ''
+  mkdir -p $out
+
+  openapi-generator-cli generate \
+    -i $src/openapi.yaml \
+    -g go \
+    -o $out \
+    -p packageName="client" \
+    -p packageVersion="0.1.0"
+
+  rm -rf \
+    $out/.gitignore \
+    $out/.openapi-generator \
+    $out/.openapi-generator-ignore \
+    $out/.travis.yml \
+    $out/README.md \
+    $out/api \
+    $out/docs \
+    $out/git_push.sh \
+    $out/test
+'';

--- a/internal/templates/templates/go-lambda/nix__default.nix
+++ b/internal/templates/templates/go-lambda/nix__default.nix
@@ -1,0 +1,14 @@
+{
+  env = {
+    CGO_ENABLED = 0;
+    {{- if .PrivateModules }}
+    GOPRIVATE = "{{ .PrivateModules }}";
+    {{- end }}
+  };
+
+  lambda = import ./lambda.nix;
+
+  {{- if .OpenAPI.Enable }}
+  client = import ./client.nix;
+  {{- end }}
+}

--- a/internal/templates/templates/go-lambda/nix__default.nix
+++ b/internal/templates/templates/go-lambda/nix__default.nix
@@ -1,4 +1,4 @@
-{
+rec {
   env = {
     CGO_ENABLED = 0;
     {{- if .PrivateModules }}
@@ -6,7 +6,7 @@
     {{- end }}
   };
 
-  lambda = import ./lambda.nix;
+  lambda = import ./lambda.nix { inherit env; };
 
   {{- if .OpenAPI.Enable }}
   client = import ./client.nix;

--- a/internal/templates/templates/go-lambda/nix__lambda.nix
+++ b/internal/templates/templates/go-lambda/nix__lambda.nix
@@ -1,3 +1,5 @@
+{ env }:
+
 {
   {{ .Nix.BuildGoModule }},
   name,
@@ -5,15 +7,12 @@
 
 {{ .Nix.BuildGoModule }} {
   inherit name;
+  inherit (env) CGO_ENABLED{{ if .PrivateModules }} GOPRIVATE{{ end }};
   ldflags = ["-s" "-w"];
   src = ../.;
   subPackages = ["cmd/${name}"];
   tags = ["lambda.norpc"];
   vendorHash = "";
-
-  {{ if .PrivateModules -}}
-  GOPRIVATE = "{{ .PrivateModules }}";
-  {{- end }}
 
   preBuild = ''
     export HOME=/tmp


### PR DESCRIPTION
## Changes

- Adds support for OpenAPI-based lambdas (primarily for the Gateway v1 REST APIs)
- Builds `lambda.zip` artifact in Nix using `<lambda-package>.passthru` (buildable by running `nix build .#lambdaName.bootstrap`.