### PR TITLE
fix: normalize filepaths when comparing to .bcignore

### DIFF
--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"text/template"
@@ -87,7 +88,8 @@ func WriteFiles(in map[string]string) error {
 		}
 
 		// Skip over files in the .bcignore file
-		if slices.Contains(ignored, filename) {
+		normalizedFilename := filepath.Base(filename)
+		if slices.Contains(ignored, normalizedFilename) {
 			continue
 		}
 


### PR DESCRIPTION
According to the README.md file, I should be able to create a .bcignore file with paths like `flake.nix` and that will ignore it and prevent that file from being generated.

I've tried this, and it doesn't work because it's trying to match on paths like `./.flake.nix`, but it doesn't.

I've created a [simple reproduction project](https://github.com/opdavies/build-configs-ignore-path-repro) based on the `go-cobra-cli` example that should ignore `flake.nix`.

I believe the fix is to normalise the file path before comparing it to the ignored files, to ensure they match as per the documentation.